### PR TITLE
Allow exr files in the dataset

### DIFF
--- a/face_api_dataset/dataset.py
+++ b/face_api_dataset/dataset.py
@@ -386,7 +386,7 @@ class FaceApiDataset(Base):
 
         metadata_records = []
         for file_path in self._root.glob("*"):
-            if file_path.name == "metadata.jsonl":
+            if file_path.name == "metadata.jsonl" or file_path.suffix == ".exr":
                 continue
 
             [scene_id, camera, frame, modality_name, modality_extension] = file_path.name.split(".")


### PR DESCRIPTION
We always supported them, but this was broken in the last update.